### PR TITLE
Use the raw disk device for better performance.

### DIFF
--- a/install
+++ b/install
@@ -108,7 +108,7 @@ promptDisk
 # ===========================================================
 
 # Format disk name to raw format
-_rawdisk=$( echo $_udisk | awk 'sub("..$", "")')
+_rawdisk=$( echo $_udisk | awk 'sub("..$", "")' | sed 's/disk/rdisk/')
 
 # Unmount Disk
 echo "Unmounting Disk"


### PR DESCRIPTION
Using `/dev/rdisk#` results in faster write performance than `/dev/disk#` as [demonstrated on Raspberry Pi Stack Exchange](http://raspberrypi.stackexchange.com/a/4059).
