### PR TITLE
2 minor changes added for extra safety

### DIFF
--- a/install
+++ b/install
@@ -75,7 +75,7 @@ function promptDisk() {
         # Increment counter
         ((i++))
 
-    done <<< "$(df -h)"
+    done <<< "$(df -lh | grep -v '/$')"
     echo -e "$_piline\n"
 
     _opts=''


### PR DESCRIPTION
to prevent wiping out the root partition by mistake.

a) look at local mounts only with df -lh
b) ignore the root mount with: grep -v '/$'
