### PR TITLE
Change "dd" optional parameter 1m to 1M

### DIFF
--- a/install
+++ b/install
@@ -116,7 +116,7 @@ diskutil unmount $_udisk
 
 echo "Writing image"
 echo "Ctrl+T to see progress.."
-sudo dd bs=1m if=${DISTRO} of=${_rawdisk}
+sudo dd bs=1M if=${DISTRO} of=${_rawdisk}
 
 # Eject disk
 echo "Ejecting Disk"


### PR DESCRIPTION
I ran the code of the latest master branch, and in my environment the following error occurred.  

> *** MAKE SURE YOU SELECT THE CORRECT DISK ***
> *** Refer to the Readme if uncertain ***
> 
> Use disk [ 1, 2 ] #2
> Unmounting Disk
> Volume TEST on disk2s1 unmounted
> Writing image
> Ctrl+T to see progress..
> dd: invalid number: ‘1m’

It seems to be resolved by capitalizing the option of dd.